### PR TITLE
Session 8 の課題を実装 : 修正提案

### DIFF
--- a/ios-training-bjung/Views/FirstViewController.swift
+++ b/ios-training-bjung/Views/FirstViewController.swift
@@ -8,10 +8,10 @@
 import UIKit
 import os
 
+private let logger: Logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "firstView")
+
 final class FirstViewController: UIViewController {
     
-    private let logger: Logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "firstView")
-
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/ios-training-bjung/Views/HomeViewController.swift
+++ b/ios-training-bjung/Views/HomeViewController.swift
@@ -9,6 +9,8 @@ import UIKit
 import YumemiWeather
 import os
 
+private let logger: Logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "homeView")
+
 final class HomeViewController: UIViewController {
     
     @IBOutlet weak var imageView: UIImageView!
@@ -16,8 +18,6 @@ final class HomeViewController: UIViewController {
     @IBOutlet weak var maxTemperatureLabel: UILabel!
     
     private var presenter: HomePresenterInput
-    
-    private let logger: Logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "homeView")
     
     init?(coder: NSCoder, presenter: HomePresenterInput) {
         self.presenter = presenter


### PR DESCRIPTION
## 概要

#8 で、Swift Concurrency のエラーチェックを厳密にした影響で、問題が発生するかもしれない箇所が Xcode の警告で見つかりました。その警告を解決するための提案です。

## セッションリンク

https://github.com/yumemi-inc/ios-training/blob/main/Documentation/UnitTest.md

## 原因

`HomeViewController` と `FirstViewController` がそれぞれ内包している `logger` を、それぞれの `deinit` 内で使用していることが原因です。

これは、`HomeViewController` と `FirstViewController` のそれぞれが継承している `UIViewController` が Main Actor 独立で動作するように定義されているため、継承先の保存型プロパティーも同様に Main Actor 独立で扱う必要が出てくることが問題になっている様子です。

それを `deinit` から使おうとすると、デイニシャライザーは Main Actor 独立が保証されてなく、かつ `Logger` 構造体が `Sendable` ではないため、スレッドを超えた（メインスレッド以外から Main Actor 独立の `logger` 変数を扱う）操作の安全性が約束できないため、警告になっていると思われます。

## 変更点

たしかな根拠が見つけられなかったので確証を見つけてもらえると嬉しいのですが、`Logger` 構造体自体はおそらく `スレッドセーフ` であるため、それ自体が `Sendable` で定義されていなくても、スレッドを気にせず呼び出して差し支えないはずです。

> スレッドセーフであると考える理由としては、Objective-C の `os_log` の仕組みがスレッドセーフを意識した作りであることと、Swift の `Logger` もそれと同じ "Unified logging system" と位置付けられているところによります。


そこで `HomeViewController` と `FirstViewController` が内包する `logger` をそれぞれその外側に移動し、Main Actor 独立の保証をなくしました。

これにより、どのスレッドから呼び出しても Swift Concurrency による検査下から外れ、警告が出ないようになりました。Logger 自体がスレッドセーフと思われるため、検査の必要なく、安全に動作すると思われます。
